### PR TITLE
ENH/ADD sntp time sync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ The purpose of this module is to **get connected** and **start streaming** as fa
 
 ## TL;DR
 
-Install via npm:
+#### Install via npm:
 
-`npm install openbci-sdk`
+```
+npm install openbci-sdk
+```
 
 #### Get connected and start streaming
 
@@ -42,9 +44,9 @@ ourBoard.connect(portName)
 
 Want to know if the module really works? Check out some projects and organizations using it:
 
-* [_OpenEXP_](https://github.com/openexp/OpenEXP) is an open-source desktop app for running experiments and collecting behavioral and physiological data.
-* [_Thinker_](http://www.pushtheworldllc.com/#!thinker/uc1fn) is a project building the world's first brainwave-word database.
-* [_NeuroJS_](https://github.com/NeuroJS) is a community dedicated to Neuroscience research using JavaScript, they have several great examples.
+* [_OpenEXP_](https://github.com/openexp/OpenEXP): an open-source desktop app for running experiments and collecting behavioral and physiological data.
+* [_Thinker_](http://www.pushtheworldllc.com/#!thinker/uc1fn): a project building the world's first brainwave-word database.
+* [_NeuroJS_](https://github.com/NeuroJS): a community dedicated to Neuroscience research using JavaScript, they have several great examples.
 
 Still not satisfied it works?? Check out this [detailed report](http://s132342840.onlinehome.us/pushtheworld/files/voltageVerificationTestPlanAndResults.pdf) that scientifically validates the output voltages of this module.
 
@@ -286,7 +288,7 @@ Board optional configurations.
 * `verbose` To output more messages to the command line.
 * `simulate` Full functionality, just synthetic data.
 * `simulatorSampleRate` - The sample rate to use for the simulator (Default is `250`)
-* `NTP` - Syncs the module up with an NTP time server. Syncs the board on startup with the NTP time. Adds a time stamp to the AUX channels. NOTE: (NOT FULLY IMPLEMENTED) [DO NOT USE]
+* `sntp` - Syncs the module up with an SNTP time server. Syncs the board on startup with the SNTP time. Adds a time stamp to the AUX channels. NOTE: (NOT FULLY IMPLEMENTED) [DO NOT USE]
 
 **Note, we have added support for either all lowercase OR camelcase of the options, use whichever style you prefer.**
 
@@ -608,6 +610,10 @@ To leave simulate mode.
 
 **_Returns_** a promise, fulfilled if able to stop simulate mode, reject if not.
 
+### .sntp
+
+Extends the popular STNP package on [npmjs](https://www.npmjs.com/package/sntp)
+
 ### .sntpGetOffset()
 
 Stateful method for querying the current offset only when the last one is too old. (defaults to daily)
@@ -616,13 +622,21 @@ Stateful method for querying the current offset only when the last one is too ol
 
 ### .sntpGetServerTime()
 
-Get time from the NTP server. Must have internet connection!
+Get time from the SNTP server. Must have internet connection!
 
 **_Returns_** a promise fulfilled with time object
 
+### .sntpNow()
+
+This function gets SNTP time since Jan 1, 1970, if we call this after a successful `.sntpStart()` this time will be sycned, or else we will just get the current computer time, the case if there is no internet. 
+
+**_Returns_** time since UNIX epoch in ms.
+
 ### .sntpStart()
 
-This starts the NTP server and gets it to remain in sync with the NTP server;
+This starts the SNTP server and gets it to remain in sync with the SNTP server;
+
+**_Returns_** a promise if the module was able to sync with ntp server.
 
 ### .sntpStop()
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,28 +1,51 @@
-0.3.0
+# 0.3.2
 
-New Features
-    * Test Signals with ADS1299 using `.testSignal()`
-    * Continuous impedance testing, where each sample gets an `impedances` object that is an array of impedances for each
+### Work In Progress
+
+* SNTP Time Synchronization
+
+### Bug Fixes
+
+* updates to README.me and comments to change ntp to sntp, because the two are similar, but not the same and we do not want to be misleading
+* Extended [Stnp](https://www.npmjs.com/package/sntp) to main openBCIBoard.js
+* Add `.sntpNow()` function to get ntp time.
+
+# 0.3.1
+
+### Bug Fixes
+
+* Bumped serialport version
+
+# 0.3.0
+
+### New Features
+
+* Test Signals with ADS1299 using `.testSignal()`
+* Continuous impedance testing, where each sample gets an `impedances` object that is an array of impedances for each
         channel.
-    * OpenBCI Radio Test File
-    * Added Sntp npm module with helper functions
-    * Removed stopByte and startByte from sampleObjects
+* OpenBCI Radio Test File
+* Added Sntp npm module with helper functions
+* Removed stopByte and startByte from sampleObjects
     
-Breaking Changes
-    * Changed simulator name to `OpenBCISimulator`
-    * Changed name of function `simulatorOn` to `simulatorEnable`
-    * Changed name of function `simulatorOff` to `simulatorDisable`
+### Breaking Changes
 
-Work In Progress
-    * NTP Time Synchronization
-    * Goertzel algorithm to get voltage for impedance calculation
+* Changed simulator name to `OpenBCISimulator`
+* Changed name of function `simulatorOn` to `simulatorEnable`
+* Changed name of function `simulatorOff` to `simulatorDisable`
+
+### Work In Progress
+
+* NTP Time Synchronization
+* Goertzel algorithm to get voltage for impedance calculation
     
-Bug fixes
-    * Impedance calculations
-    * Readme updates
-    * Serial buffer had the chance to become permanently unaligned, optimized and completely transformed and refactored the way bytes are processed.
-    * Changes to gain of channels not working correctly.
-    * Node 5 compatibility 
+### Bug fixes
+
+* Impedance calculations
+* Readme updates
+* Serial buffer had the chance to become permanently unaligned, optimized and completely transformed and refactored the way bytes are processed.
+* Changes to gain of channels not working correctly.
+* Node 5 compatibility 
     
-Github Issues Addressed
-    * #25, #26, #27, #29, #30, #31, #33, #34
+### Github Issues Addressed
+
+* #25, #26, #27, #29, #30, #31, #33, #34

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A fully NodeJS based API for the OpenBCI board connecting to the hardware directly over serial",
   "main": "openBCIBoard",
   "scripts": {

--- a/test/openbci-sdk-test.js
+++ b/test/openbci-sdk-test.js
@@ -1101,18 +1101,15 @@ describe('#impedanceTesting', function() {
     });
 });
 
-xdescribe('#sync', function() {
+describe('#sync', function() {
     var ourBoard;
     this.timeout(5000);
     before(function (done) {
-        ourBoard = new openBCIBoard.OpenBCIBoard({
-            verbose: true
-        });
+        ourBoard = new openBCIBoard.OpenBCIBoard();
 
         var useSim = () => {
             ourBoard.simulatorEnable()
                 .then(() => {
-
                     return ourBoard.connect(k.OBCISimulatorPortName);
                 })
                 .then(() => {
@@ -1128,7 +1125,7 @@ xdescribe('#sync', function() {
                 useSim();
             })
             .then(() => {
-                console.log('connected');
+                //console.log('connected');
             })
             .catch(err => {
                 console.log('Error: ' + err);
@@ -1144,7 +1141,13 @@ xdescribe('#sync', function() {
         ourBoard.disconnect();
     });
     describe('#sntp', function() {
-        it('can get current ntp time', function(done) {
+        it('can get sntp time and verify extend of sntp valid', function(done) {
+            ourBoard.sntpStart()
+                .then(() => {
+                    // sntp.now should be extended into ourBoard.sntpNow
+                    ourBoard.sntpNow().should.equal(ourBoard.sntp.now());
+                    done();
+                });
 
         });
     });


### PR DESCRIPTION
I added a key function for SNTP, called `.sntpNow()` I also simply extended sntp class so we could call into that if need by in the future.