### PR TITLE
Dev serialport upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
   - "4.0"
+  - "4.1"
+  - "4.2"
   - "5.11.0"
+  - "6.0"
+  - "6.1"
+  - "6.2"
 install:
   - npm install --all
 script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {
@@ -19,7 +19,7 @@
     "istanbul": "^0.4.2",
     "performance-now": "^0.2.0",
     "scientific-statistics": "^0.2.7",
-    "serialport": "~3.0.0",
+    "serialport": "3.1.2",
     "sntp": "^2.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gaussian": "^1.0.0",
     "istanbul": "^0.4.2",
     "performance-now": "^0.2.0",
-    "serialport": "~2.1.0",
+    "scientific-statistics": "^0.2.7",
+    "serialport": "~3.0.0",
     "sntp": "^2.0.0"
   },
   "directories": {


### PR DESCRIPTION
This adds support for running node version 6.x.x by upgrading serialport to version 6.