### PR TITLE
Validate packets before emitting raw data packets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+# 0.3.9
+
+### Enhancements
+
+* Add tests for parsing raw packets
+
+### Bug Fixes
+
+* Removed `got here` log from `.streamStart()`
+* Validate stop byte before emitting `rawDataPacket`
+
 # 0.3.8
 
 ### Bug Fixes

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -266,7 +266,6 @@ function OpenBCIFactory() {
      */
     OpenBCIBoard.prototype.streamStart = function() {
         return new Promise((resolve, reject) => {
-            console.log('got here');
             if(this.streaming) reject('Error [.streamStart()]: Already streaming');
             this.streaming = true;
             this._reset();
@@ -1149,8 +1148,8 @@ function OpenBCIFactory() {
             while (readingPosition <= bytesToRead - k.OBCIPacketSize) {
                 if (data[readingPosition] === k.OBCIByteStart) {
                     var rawPacket = data.slice(readingPosition, readingPosition + k.OBCIPacketSize);
-                    this.emit('rawDataPacket',rawPacket);
                     if (data[readingPosition + k.OBCIPacketSize - 1] === k.OBCIByteStop) {
+                        this.emit('rawDataPacket',rawPacket);
                         // standard packet!
                         openBCISample.parseRawPacket(rawPacket,this.channelSettingsArray)
                             .then(sampleObject => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-sdk",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {


### PR DESCRIPTION
### Enhancements

* Add tests for parsing raw packets

### Bug Fixes

* Removed `got here` log from `.streamStart()`
* Validate stop byte before emitting `rawDataPacket`